### PR TITLE
fix(delegation): reject token issuer/credential SPIFFE ID mismatch (/cso #1, CRITICAL)

### DIFF
--- a/examples/exploit_attempt.rs
+++ b/examples/exploit_attempt.rs
@@ -1,0 +1,91 @@
+//! Exploit attempt: demonstrates that DelegationToken::verify rejects issuer spoofing.
+//!
+//! Finding #1 from the /cso audit: an attacker who generates their own keypair
+//! can mint a token that claims to be issued by any SPIFFE ID by:
+//!   1. Generating a legitimate AgentIdentity (attacker's own)
+//!   2. Using DelegationToken::issue() to create a valid token as the attacker
+//!   3. Post-issue: swapping the `issuer` field to claim victim's SPIFFE ID
+//!   4. Calling verify() — the embedded credential's spiffe_id still names the
+//!      attacker, while issuer now names the victim.
+//!
+//! Before the fix: verify() returned Ok because it only checked the signature
+//! against the embedded key, not whether the embedded key belongs to the claimed issuer.
+//! After the fix: verify() returns Err(ChainVerificationFailed) with "does not match".
+
+use okami::delegation::{Capability, DelegationToken};
+use okami::identity::{AgentIdentity, SpiffeId};
+use std::time::Duration;
+
+fn main() {
+    println!("=== Exploit Attempt: Issuer Spoofing (Finding #1) ===\n");
+
+    // Step 1: Attacker generates their own legitimate keypair.
+    let attacker = AgentIdentity::new("evil.example", "attacker").expect("attacker identity");
+
+    // Step 2: Attacker picks a victim SPIFFE ID they want to impersonate.
+    let victim_spiffe = SpiffeId::new("corp.internal", "admin").expect("victim spiffe id");
+
+    // Step 3: Attacker issues a valid token from their own identity to some subject.
+    // (This part is fine — attacker is allowed to issue tokens as themselves.)
+    let subject = SpiffeId::new("evil.example", "puppet").expect("subject spiffe id");
+    let scopes = vec![Capability::new("write:payroll").expect("scope")];
+
+    let mut forged_token = DelegationToken::issue(
+        &attacker,
+        subject,
+        scopes.clone(),
+        &scopes,
+        Duration::from_secs(3600),
+        None,
+    )
+    .expect("issue attacker token");
+
+    println!("Step 1-3: Attacker issues a valid token as themselves.");
+    println!("  Real attacker SPIFFE ID:  {}", attacker.spiffe_id());
+    println!("  Token issuer (pre-swap):   {}", forged_token.issuer);
+    println!(
+        "  Embedded cred subject:     {}",
+        forged_token.issuer_credential.spiffe_id
+    );
+
+    // Step 4: Attacker swaps the `issuer` field to claim victim's identity.
+    // The embedded issuer_credential still has attacker's SPIFFE ID and key.
+    // The signature remains valid (it was signed by attacker's key over the
+    // original payload bytes). This is the core of the exploit.
+    forged_token.issuer = victim_spiffe.clone();
+
+    println!("\nStep 4: Attacker swaps issuer field to impersonate victim.");
+    println!("  Token issuer (post-swap):  {}", forged_token.issuer);
+    println!(
+        "  Embedded cred subject:     {}",
+        forged_token.issuer_credential.spiffe_id
+    );
+    println!("  Claimed scope:             write:payroll");
+
+    // Step 5: Attempt verification. Before the fix this would return Ok.
+    println!("\nStep 5: Calling token.verify(None)...");
+    let result = forged_token.verify(None);
+
+    match &result {
+        Ok(()) => {
+            eprintln!("\n[FAIL] VULNERABILITY PRESENT: forged token verified successfully!");
+            eprintln!("  The exploit succeeded — attacker can impersonate {victim_spiffe}");
+            std::process::exit(1);
+        }
+        Err(e) => {
+            println!("\n[PASS] Exploit blocked. verify() returned:");
+            println!("  Err({e})");
+            let msg = e.to_string();
+            if msg.contains("does not match") {
+                println!("\nFix confirmed: error mentions \"does not match\" as expected.");
+                println!(
+                    "An attacker cannot forge tokens claiming to be issued by {victim_spiffe}."
+                );
+            } else {
+                println!(
+                    "\nNote: error does not contain \"does not match\" — may be a different guard."
+                );
+            }
+        }
+    }
+}

--- a/src/delegation.rs
+++ b/src/delegation.rs
@@ -212,12 +212,38 @@ impl DelegationToken {
 
     /// Verify this token's signature and validity window.
     ///
-    /// Checks: not expired, not issued in the far future, PQC signature valid.
+    /// Checks: issuer/credential binding, not expired, not issued in the far
+    /// future, PQC signature valid.
     ///
     /// # Parameters
     ///
     /// - `clock_skew` — grace period (default: 30 seconds)
+    //
+    // @decision DEC-OKAMI-014
+    // @title Verify embedded credential SPIFFE ID matches claimed issuer
+    // @status accepted
+    // @rationale DelegationToken::verify uses the verifying key from the embedded
+    //   issuer_credential. Without checking that issuer_credential.spiffe_id matches
+    //   the claimed issuer, any keypair holder could forge tokens claiming any issuer
+    //   identity: they generate their own AgentIdentity, set issuer = <victim SPIFFE ID>,
+    //   embed their own credential, sign the UnsignedToken with their key, and
+    //   verify() returns Ok because the signature check only validates that the
+    //   payload was signed by the embedded key — not that the embedded key belongs
+    //   to the claimed issuer. The check is placed before time-window validation so
+    //   the error is stable regardless of system clock state.
+    //   See /cso report 2026-04-24 Finding #1
+    //   (fingerprint fc51b5488084256e84c03c389a26d5899f5424399d8d4fe99fc9e0e5ff8baeb8).
     pub fn verify(&self, clock_skew: Option<StdDuration>) -> Result<()> {
+        // Invariant: the claimed issuer must be the subject of the embedded credential.
+        // A token whose issuer field names entity X but embeds Y's verifying key is
+        // a forgery — reject before touching the clock.
+        if self.issuer != self.issuer_credential.spiffe_id {
+            return Err(Error::ChainVerificationFailed(format!(
+                "issuer {} does not match embedded credential subject {}",
+                self.issuer, self.issuer_credential.spiffe_id
+            )));
+        }
+
         let skew_secs = clock_skew
             .unwrap_or(StdDuration::from_secs(DEFAULT_CLOCK_SKEW_SECS))
             .as_secs() as i64;
@@ -870,6 +896,121 @@ mod tests {
             .unwrap();
             let chain = DelegationChain::new(vec![token]);
             assert_eq!(chain.effective_scopes().len(), 2);
+        });
+    }
+
+    // ── Security regression: issuer/credential mismatch (Finding #1) ──────────
+
+    /// An attacker with their own valid keypair forges a token claiming to be
+    /// issued by a different SPIFFE ID. The signature is cryptographically valid
+    /// (the attacker signs with their own key), but the issuer field names a
+    /// different identity than the embedded credential. verify() must reject it.
+    #[test]
+    fn delegation_token_verify_rejects_issuer_credential_mismatch() {
+        with_large_stack(|| {
+            // Attacker generates a legitimate keypair for their own identity.
+            let attacker = AgentIdentity::new("example.com", "attacker").unwrap();
+            // Victim identity the attacker wants to impersonate.
+            let victim_id = SpiffeId::new("example.com", "victim").unwrap();
+            let subject_id = SpiffeId::new("example.com", "subject").unwrap();
+
+            let scopes = vec![Capability::new("read:db").unwrap()];
+            let now = chrono::Utc::now();
+
+            // Build the UnsignedToken as the attacker would: claiming victim as issuer.
+            let unsigned = UnsignedToken {
+                issuer: victim_id.clone(),
+                subject: subject_id.clone(),
+                scopes: scopes.clone(),
+                issued_at: now,
+                expires_at: now + chrono::Duration::seconds(3600),
+                parent_token_hash: None,
+                depth: 0,
+            };
+            let payload_bytes = bincode::serialize(&unsigned).unwrap();
+
+            // Attacker signs with their own key — signature is valid for the payload.
+            let signature = attacker.sign(&payload_bytes).unwrap();
+
+            // Construct a token where issuer claims to be victim but embeds attacker's
+            // credential (whose spiffe_id == attacker, not victim).
+            let forged = DelegationToken {
+                issuer: victim_id.clone(),
+                subject: subject_id,
+                scopes,
+                issued_at: now,
+                expires_at: now + chrono::Duration::seconds(3600),
+                parent_token_hash: None,
+                depth: 0,
+                issuer_credential: attacker.credential(), // attacker's cred, not victim's
+                signature,
+            };
+
+            let result = forged.verify(None);
+            assert!(
+                matches!(result, Err(Error::ChainVerificationFailed(ref msg)) if msg.contains("does not match")),
+                "expected ChainVerificationFailed(\"does not match ...\"), got: {result:?}"
+            );
+        });
+    }
+
+    /// End-to-end chain variant: a root token with mismatched issuer/credential
+    /// must cause chain.verify() to fail at the root, even when a legitimate-
+    /// looking child token chains off it.
+    #[test]
+    fn delegation_chain_rejects_forged_root_with_mismatched_credential() {
+        with_large_stack(|| {
+            let attacker = AgentIdentity::new("example.com", "attacker").unwrap();
+            let legitimate_worker = AgentIdentity::new("example.com", "worker/1").unwrap();
+            let victim_id = SpiffeId::new("example.com", "victim").unwrap();
+            let subject_id = legitimate_worker.spiffe_id().clone();
+
+            let scopes = vec![Capability::new("read:db").unwrap()];
+            let now = chrono::Utc::now();
+
+            // Forge the root token: issuer claims victim but embeds attacker's credential.
+            let unsigned_root = UnsignedToken {
+                issuer: victim_id.clone(),
+                subject: subject_id.clone(),
+                scopes: scopes.clone(),
+                issued_at: now,
+                expires_at: now + chrono::Duration::seconds(3600),
+                parent_token_hash: None,
+                depth: 0,
+            };
+            let root_payload = bincode::serialize(&unsigned_root).unwrap();
+            let root_sig = attacker.sign(&root_payload).unwrap();
+
+            let forged_root = DelegationToken {
+                issuer: victim_id,
+                subject: subject_id,
+                scopes: scopes.clone(),
+                issued_at: now,
+                expires_at: now + chrono::Duration::seconds(3600),
+                parent_token_hash: None,
+                depth: 0,
+                issuer_credential: attacker.credential(),
+                signature: root_sig,
+            };
+
+            // Build a legitimate child token that chains off the forged root.
+            let leaf_subject = SpiffeId::new("example.com", "leaf").unwrap();
+            let child = DelegationToken::issue(
+                &legitimate_worker,
+                leaf_subject,
+                scopes.clone(),
+                &scopes,
+                StdDuration::from_secs(1800),
+                Some(&forged_root),
+            )
+            .unwrap();
+
+            let chain = DelegationChain::new(vec![forged_root, child]);
+            let result = chain.verify(None);
+            assert!(
+                matches!(result, Err(Error::ChainVerificationFailed(_))),
+                "expected ChainVerificationFailed, got: {result:?}"
+            );
         });
     }
 }


### PR DESCRIPTION
## Summary

- Adds an issuer/credential binding guard at the top of `DelegationToken::verify`
- Without this, any PQC keypair holder could forge tokens claiming any SPIFFE issuer ID — full bypass of the self-contained trust model
- `examples/exploit_attempt.rs` is a runnable regression witness

## Findings closed

- #1 — CRITICAL — Issuer spoofing via unchecked embedded credential

## Verification (already run on the branch)

- 103/103 tests pass (2 new security tests)
- Live `cargo run --example exploit_attempt` rejects forged token with "does not match"
- `cargo run --example mutual_auth` happy path unbroken

## Test plan

- [ ] CI green
- [ ] Live re-run of `cargo run --example exploit_attempt` after merge — must print PASS

> ⚠️ This PR may have rustfmt violations against the pre-existing main; rebase against #5/#6/#7 (or merge that PR first) to clear the fmt gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
