### PR TITLE
fix(codec): bound bincode deserialization inputs (/cso #4)

### DIFF
--- a/examples/bincode_exploit.rs
+++ b/examples/bincode_exploit.rs
@@ -1,0 +1,29 @@
+/// Regression witness for /cso Finding #4 — bincode allocation DoS.
+///
+/// Verifies that a crafted 8-byte length prefix of 0xFF...FF is rejected
+/// immediately by the bounded deserializer, without attempting allocation
+/// and without panicking or hanging.
+fn main() {
+    // Craft a minimal payload: 8 bytes of 0xFF (u64::MAX as a length prefix
+    // for the first Vec field in bincode's encoding) + 8 bytes of padding.
+    // An unbounded deserializer would attempt to allocate ~18 exabytes.
+    let evil = vec![0xFFu8; 16];
+
+    let t0 = std::time::Instant::now();
+    let result = okami::delegation::DelegationChain::from_bytes(&evil);
+    let elapsed = t0.elapsed();
+
+    println!("Result: {result:?}");
+    println!("Elapsed: {elapsed:?}");
+
+    // Sanity-check: must be an error
+    assert!(result.is_err(), "Expected Err, got Ok — limit not active!");
+
+    // Sanity-check: must be fast (well under 100ms)
+    assert!(
+        elapsed.as_millis() < 100,
+        "Elapsed {elapsed:?} exceeds 100ms — limit may not be applied before allocation"
+    );
+
+    println!("PASS: exploit rejected in {elapsed:?}");
+}

--- a/examples/boundary_check.rs
+++ b/examples/boundary_check.rs
@@ -1,0 +1,89 @@
+/// Boundary-behavior test for DelegationToken size cap (MAX_TOKEN_BYTES = 8 KiB).
+///
+/// Verifies:
+/// 1. A valid token round-trips fine (it's well under 8 KiB).
+/// 2. A valid token whose serialization exceeds 8 KiB is rejected by from_bytes.
+///
+/// Run: cargo run --example boundary_check
+fn main() {
+    use okami::delegation::{Capability, DelegationToken, MAX_TOKEN_BYTES};
+    use okami::identity::{AgentIdentity, SpiffeId};
+    use std::time::Duration;
+
+    // -- Setup: create a signing identity.
+    let subject_id = SpiffeId::new("example.com", "/subject").unwrap();
+    let issuer = AgentIdentity::new("example.com", "/issuer").unwrap();
+
+    // -- Part 1: A normal token should round-trip.
+    let scopes = vec![
+        Capability::new("read:db").unwrap(),
+        Capability::new("invoke:llm").unwrap(),
+    ];
+    let issuer_scopes = scopes.clone();
+    let token = DelegationToken::issue(
+        &issuer,
+        subject_id.clone(),
+        scopes,
+        &issuer_scopes,
+        Duration::from_secs(3600),
+        None,
+    )
+    .expect("issue failed");
+
+    let bytes = token.to_bytes().expect("to_bytes failed");
+    println!(
+        "Normal token serialized size: {} bytes (limit: {})",
+        bytes.len(),
+        MAX_TOKEN_BYTES
+    );
+    assert!(
+        bytes.len() < MAX_TOKEN_BYTES as usize,
+        "Normal token unexpectedly exceeds limit: {} >= {}",
+        bytes.len(),
+        MAX_TOKEN_BYTES
+    );
+
+    let rt = DelegationToken::from_bytes(&bytes).expect("round-trip failed for normal token");
+    println!("Round-trip OK: issuer = {}", rt.issuer);
+
+    // -- Part 2: Construct a valid token with many scopes so serialized size > 8 KiB.
+    // 500 scopes of 20 chars each = ~10 KiB of scope strings alone.
+    let big_scopes: Vec<Capability> = (0..500)
+        .map(|i| Capability::new(&format!("scope:aaaaaaaaaaa{i:04}")).unwrap())
+        .collect();
+    // Cap to issuer's perspective — all those are the issuer's scopes too.
+    let big_issuer_scopes = big_scopes.clone();
+
+    let big_token = DelegationToken::issue(
+        &issuer,
+        subject_id,
+        big_scopes.clone(),
+        &big_issuer_scopes,
+        Duration::from_secs(3600),
+        None,
+    )
+    .expect("issue big token failed");
+
+    let big_bytes = big_token.to_bytes().expect("to_bytes failed for big token");
+    println!(
+        "Oversized token serialized size: {} bytes (limit: {})",
+        big_bytes.len(),
+        MAX_TOKEN_BYTES
+    );
+
+    if big_bytes.len() <= MAX_TOKEN_BYTES as usize {
+        println!(
+            "WARNING: oversized token ({} bytes) is still under the limit — \
+             try increasing scope count",
+            big_bytes.len()
+        );
+    } else {
+        let result = DelegationToken::from_bytes(&big_bytes);
+        println!("from_bytes result for oversized valid token: {result:?}");
+        assert!(
+            result.is_err(),
+            "Expected Err for oversized token, got Ok — limit not enforced on valid data!"
+        );
+        println!("PASS: oversized valid token rejected correctly.");
+    }
+}

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -26,6 +26,14 @@ use crate::identity::{AgentIdentity, SpiffeId};
 /// Version byte for audit event format. Version 1 = current format.
 pub const AUDIT_EVENT_VERSION: u8 = 1;
 
+/// Maximum byte size accepted by [`SignedAuditEvent::from_bytes`].
+///
+/// Events contain a `details_json` string (variable-length JSON), a PQC signature
+/// (~3.3 KiB for ML-DSA-65), and metadata fields. 16 KiB allows generous JSON
+/// detail blobs while blocking allocation-DoS via crafted length prefixes.
+/// See `/cso` audit Finding #4.
+pub const MAX_SIGNED_AUDIT_EVENT_BYTES: u64 = 16 * 1024;
+
 // ── AuditEvent ────────────────────────────────────────────────────────────────
 
 /// An unsigned audit event recording an agent action.
@@ -185,8 +193,29 @@ impl SignedAuditEvent {
     }
 
     /// Deserialize from bytes (bincode).
+    ///
+    /// Enforces a [`MAX_SIGNED_AUDIT_EVENT_BYTES`] allocation cap to prevent DoS
+    /// via crafted length-prefix fields. See `/cso` audit Finding #4 (fingerprint
+    /// `30a553fc`).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Serialization`] if the input exceeds `MAX_SIGNED_AUDIT_EVENT_BYTES` or
+    /// if bincode decoding fails.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
-        bincode::deserialize(bytes)
+        if bytes.len() as u64 > MAX_SIGNED_AUDIT_EVENT_BYTES {
+            return Err(Error::Serialization(format!(
+                "input exceeds maximum size ({} > {})",
+                bytes.len(),
+                MAX_SIGNED_AUDIT_EVENT_BYTES
+            )));
+        }
+        use bincode::Options as _;
+        bincode::DefaultOptions::new()
+            .with_fixint_encoding()
+            .allow_trailing_bytes()
+            .with_limit(MAX_SIGNED_AUDIT_EVENT_BYTES)
+            .deserialize(bytes)
             .map_err(|e| Error::Serialization(format!("signed event deserialize: {e}")))
     }
 }
@@ -486,5 +515,26 @@ mod tests {
             assert!(signed.verify(&vk_bytes).unwrap());
             assert_eq!(signed.event.details(), details);
         });
+    }
+
+    // ── Security: allocation-DoS rejection ────────────────────────────────────
+
+    /// Feeding a payload whose first 8 bytes are 0xFF (a u64 length prefix of
+    /// ~18 exabytes) to SignedAuditEvent::from_bytes must return Err, not panic.
+    /// Regression test for /cso Finding #4 (fingerprint `30a553fc`).
+    #[test]
+    fn signed_audit_event_from_bytes_rejects_oversized_length_prefix() {
+        let mut crafted = vec![0xFFu8; 8];
+        crafted.extend_from_slice(&[0u8; 16]);
+        let result = SignedAuditEvent::from_bytes(&crafted);
+        assert!(
+            result.is_err(),
+            "oversized length prefix must be rejected, got Ok"
+        );
+        assert!(
+            matches!(result, Err(Error::Serialization(_))),
+            "expected Serialization error, got: {:?}",
+            result
+        );
     }
 }

--- a/src/delegation.rs
+++ b/src/delegation.rs
@@ -17,6 +17,20 @@
 // @decision DEC-OKAMI-007 Clock skew tolerance: configurable, default 30s — accepted.
 // Rationale: distributed systems have clock drift. 30s prevents spurious failures
 // in well-behaved environments. Operators can set it to zero.
+//
+// @decision DEC-OKAMI-016
+// @title Bounded bincode deserialization to prevent allocation DoS
+// @status accepted
+// @rationale bincode 1.x reads a raw u64 length prefix before allocating for
+//   Vec<T>/String fields. A crafted payload with `[0xFF; 8]` as the first field
+//   causes an immediate multi-exabyte allocation attempt, crashing the process.
+//   Fix: use `DefaultOptions::with_fixint_encoding().allow_trailing_bytes().with_limit(N)`
+//   which exactly mirrors the free-function default encoding but adds an allocation cap.
+//   The legacy `bincode::config()` builder internally expands to the same Options chain
+//   (confirmed via bincode 1.3.3 src/config/legacy.rs) but is deprecated since 1.3.0.
+//   Limits: DelegationToken 8 KiB (embeds PqcCredential ~2 KiB + sig + scopes),
+//   DelegationChain 32 KiB (max 3 tokens × 8 KiB + headroom).
+//   See `/cso` audit Finding #4 (fingerprint `30a553fc`).
 
 use std::time::Duration as StdDuration;
 
@@ -35,6 +49,20 @@ pub const MAX_DELEGATION_DEPTH: u32 = 2;
 
 /// Default clock skew tolerance in seconds.
 pub const DEFAULT_CLOCK_SKEW_SECS: u64 = 30;
+
+/// Maximum byte size accepted by [`DelegationToken::from_bytes`].
+///
+/// A token embeds the issuer's [`PqcCredential`] (~2 KiB), the PQC signature
+/// (~3.3 KiB for ML-DSA-65), SPIFFE IDs, scopes, and timestamps. 8 KiB provides
+/// generous headroom while blocking allocation-DoS via crafted length prefixes.
+/// See `/cso` audit Finding #4.
+pub const MAX_TOKEN_BYTES: u64 = 8 * 1024;
+
+/// Maximum byte size accepted by [`DelegationChain::from_bytes`].
+///
+/// A chain holds up to 3 tokens (max depth). At 8 KiB each plus framing,
+/// 32 KiB provides ample headroom. See `/cso` audit Finding #4.
+pub const MAX_CHAIN_BYTES: u64 = 32 * 1024;
 
 // ── Capability ────────────────────────────────────────────────────────────────
 
@@ -292,8 +320,28 @@ impl DelegationToken {
     }
 
     /// Deserialize a token from bytes (bincode).
+    ///
+    /// Enforces a [`MAX_TOKEN_BYTES`] allocation cap to prevent DoS via crafted
+    /// length-prefix fields. See `/cso` audit Finding #4 (fingerprint `30a553fc`).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Serialization`] if the input exceeds `MAX_TOKEN_BYTES` or
+    /// if bincode decoding fails.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
-        bincode::deserialize(bytes)
+        if bytes.len() as u64 > MAX_TOKEN_BYTES {
+            return Err(Error::Serialization(format!(
+                "input exceeds maximum size ({} > {})",
+                bytes.len(),
+                MAX_TOKEN_BYTES
+            )));
+        }
+        use bincode::Options as _;
+        bincode::DefaultOptions::new()
+            .with_fixint_encoding()
+            .allow_trailing_bytes()
+            .with_limit(MAX_TOKEN_BYTES)
+            .deserialize(bytes)
             .map_err(|e| Error::Serialization(format!("token deserialize: {e}")))
     }
 
@@ -409,8 +457,28 @@ impl DelegationChain {
     }
 
     /// Deserialize a chain from bytes (bincode).
+    ///
+    /// Enforces a [`MAX_CHAIN_BYTES`] allocation cap to prevent DoS via crafted
+    /// length-prefix fields. See `/cso` audit Finding #4 (fingerprint `30a553fc`).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Serialization`] if the input exceeds `MAX_CHAIN_BYTES` or
+    /// if bincode decoding fails.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
-        bincode::deserialize(bytes)
+        if bytes.len() as u64 > MAX_CHAIN_BYTES {
+            return Err(Error::Serialization(format!(
+                "input exceeds maximum size ({} > {})",
+                bytes.len(),
+                MAX_CHAIN_BYTES
+            )));
+        }
+        use bincode::Options as _;
+        bincode::DefaultOptions::new()
+            .with_fixint_encoding()
+            .allow_trailing_bytes()
+            .with_limit(MAX_CHAIN_BYTES)
+            .deserialize(bytes)
             .map_err(|e| Error::Serialization(format!("chain deserialize: {e}")))
     }
 
@@ -1010,6 +1078,96 @@ mod tests {
             assert!(
                 matches!(result, Err(Error::ChainVerificationFailed(_))),
                 "expected ChainVerificationFailed, got: {result:?}"
+            );
+        });
+    }
+
+    // ── Security: allocation-DoS rejection (Finding #4) ───────────────────────
+
+    /// Feeding a payload whose first 8 bytes are 0xFF (a u64 length prefix of
+    /// ~18 exabytes) to DelegationToken::from_bytes must return Err, not panic.
+    /// Regression test for /cso Finding #4 (fingerprint `30a553fc`).
+    #[test]
+    fn delegation_token_from_bytes_rejects_oversized_length_prefix() {
+        let mut crafted = vec![0xFFu8; 8];
+        crafted.extend_from_slice(&[0u8; 16]);
+        let result = DelegationToken::from_bytes(&crafted);
+        assert!(
+            result.is_err(),
+            "oversized length prefix must be rejected, got Ok"
+        );
+        assert!(
+            matches!(result, Err(Error::Serialization(_))),
+            "expected Serialization error, got: {:?}",
+            result
+        );
+    }
+
+    /// Feeding a payload whose first 8 bytes are 0xFF to DelegationChain::from_bytes
+    /// must return Err, not panic or OOM.
+    /// Regression test for /cso Finding #4 (fingerprint `30a553fc`).
+    #[test]
+    fn delegation_chain_from_bytes_rejects_oversized_length_prefix() {
+        let mut crafted = vec![0xFFu8; 8];
+        crafted.extend_from_slice(&[0u8; 16]);
+        let result = DelegationChain::from_bytes(&crafted);
+        assert!(
+            result.is_err(),
+            "oversized length prefix must be rejected, got Ok"
+        );
+        assert!(
+            matches!(result, Err(Error::Serialization(_))),
+            "expected Serialization error, got: {:?}",
+            result
+        );
+    }
+
+    /// A valid but oversized DelegationToken (serialized size > MAX_TOKEN_BYTES)
+    /// must be rejected by from_bytes before bincode is invoked.
+    ///
+    /// Uses 500 scopes (~20 chars each) to push the token over 8 KiB.
+    /// Regression test for the boundary invariant gap reported by the tester.
+    #[test]
+    fn delegation_token_from_bytes_rejects_oversized_valid_input() {
+        with_large_stack(|| {
+            let issuer = AgentIdentity::new("example.com", "orchestrator").unwrap();
+            let subject_id = SpiffeId::new("example.com", "worker/oversized").unwrap();
+
+            // 500 scopes of ~20 chars each yields ~20 KiB serialized — well over MAX_TOKEN_BYTES (8 KiB).
+            let big_scopes: Vec<Capability> = (0..500)
+                .map(|i| Capability::new(&format!("scope:aaaaaaaaaaa{i:04}")).unwrap())
+                .collect();
+            let big_issuer_scopes = big_scopes.clone();
+
+            let big_token = DelegationToken::issue(
+                &issuer,
+                subject_id,
+                big_scopes,
+                &big_issuer_scopes,
+                std::time::Duration::from_secs(3600),
+                None,
+            )
+            .expect("issue oversized token failed");
+
+            let big_bytes = big_token
+                .to_bytes()
+                .expect("to_bytes failed for oversized token");
+            assert!(
+                big_bytes.len() as u64 > MAX_TOKEN_BYTES,
+                "oversized token must exceed MAX_TOKEN_BYTES ({} <= {})",
+                big_bytes.len(),
+                MAX_TOKEN_BYTES
+            );
+
+            let result = DelegationToken::from_bytes(&big_bytes);
+            assert!(
+                result.is_err(),
+                "Expected Err for oversized valid token, got Ok"
+            );
+            let err_str = format!("{:?}", result);
+            assert!(
+                err_str.contains("exceeds maximum"),
+                "error must mention 'exceeds maximum', got: {err_str}"
             );
         });
     }

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -41,6 +41,18 @@
 //!   to load keys with permissions wider than 0600 forces operators to handle
 //!   key material correctly. This matches the SSH convention, which users
 //!   already understand. Windows support is deferred (no equivalent ACL model).
+//!
+//! @decision DEC-OKAMI-016
+//! @title Bounded bincode deserialization to prevent allocation DoS
+//! @status accepted
+//! @rationale bincode 1.x reads a raw u64 length prefix before allocating for
+//!   Vec<T>/String fields. A crafted payload with `[0xFF; 8]` as the first field
+//!   causes an immediate multi-exabyte allocation attempt, crashing the process.
+//!   Fix: use `DefaultOptions::with_fixint_encoding().allow_trailing_bytes().with_limit(N)`
+//!   which exactly mirrors the free-function encoding but adds an allocation cap.
+//!   Limits (PqcCredential: 4 KiB, DelegationToken: 8 KiB, DelegationChain: 32 KiB,
+//!   SignedAuditEvent: 16 KiB) are generous relative to actual sizes while blocking
+//!   the attack. See `/cso` audit Finding #4 (fingerprint `30a553fc`).
 
 use std::fmt;
 
@@ -57,6 +69,14 @@ pub const DEFAULT_VALIDITY_DAYS: i64 = 365;
 /// Algorithm tag stored in PqcCredential to identify the key type.
 /// Version 1 = Hybrid Ed25519 + ML-DSA-65.
 const CREDENTIAL_ALGO_V1: u8 = 0x01;
+
+/// Maximum byte size accepted by [`PqcCredential::from_bytes`].
+///
+/// Actual serialized size is ~2 KiB (verifying key ~1984 bytes + SPIFFE ID +
+/// timestamps + algo byte). 4 KiB provides headroom for longer SPIFFE IDs
+/// while preventing multi-exabyte allocation attacks via crafted length prefixes.
+/// See `/cso` audit Finding #4.
+pub const MAX_CREDENTIAL_BYTES: u64 = 4 * 1024;
 
 // ── SpiffeId ──────────────────────────────────────────────────────────────────
 
@@ -234,11 +254,28 @@ impl PqcCredential {
 
     /// Deserialize a credential from bytes (bincode).
     ///
+    /// Enforces a [`MAX_CREDENTIAL_BYTES`] allocation cap to prevent DoS via
+    /// crafted length-prefix fields (e.g. `[0xFF; 8]` triggering multi-exabyte
+    /// allocation). See `/cso` audit Finding #4 (fingerprint `30a553fc`).
+    ///
     /// # Errors
     ///
-    /// Returns [`Error::Serialization`] if bincode decoding fails.
+    /// Returns [`Error::Serialization`] if the input exceeds `MAX_CREDENTIAL_BYTES` or
+    /// if bincode decoding fails.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
-        bincode::deserialize(bytes)
+        if bytes.len() as u64 > MAX_CREDENTIAL_BYTES {
+            return Err(Error::Serialization(format!(
+                "input exceeds maximum size ({} > {})",
+                bytes.len(),
+                MAX_CREDENTIAL_BYTES
+            )));
+        }
+        use bincode::Options as _;
+        bincode::DefaultOptions::new()
+            .with_fixint_encoding()
+            .allow_trailing_bytes()
+            .with_limit(MAX_CREDENTIAL_BYTES)
+            .deserialize(bytes)
             .map_err(|e| Error::Serialization(format!("credential deserialize: {e}")))
     }
 }
@@ -870,5 +907,26 @@ mod tests {
             let result = load_signing_key(&path);
             assert!(matches!(result, Err(Error::InsecureKeyPermissions)));
         });
+    }
+
+    // ── Security: allocation-DoS rejection ────────────────────────────────────
+
+    /// Feeding a payload whose first 8 bytes are 0xFF (a u64 length prefix of
+    /// ~18 exabytes) must return Err, not panic or OOM.
+    /// Regression test for /cso Finding #4 (fingerprint `30a553fc`).
+    #[test]
+    fn pqc_credential_from_bytes_rejects_oversized_length_prefix() {
+        let mut crafted = vec![0xFFu8; 8];
+        crafted.extend_from_slice(&[0u8; 16]); // some trailing bytes
+        let result = PqcCredential::from_bytes(&crafted);
+        assert!(
+            result.is_err(),
+            "oversized length prefix must be rejected, got Ok"
+        );
+        assert!(
+            matches!(result, Err(Error::Serialization(_))),
+            "expected Serialization error, got: {:?}",
+            result
+        );
     }
 }

--- a/tests/proptest_tests.rs
+++ b/tests/proptest_tests.rs
@@ -434,3 +434,24 @@ fn adversarial_boundary_expiry() {
         fresh_token.verify(Some(Duration::from_secs(30))).unwrap();
     });
 }
+
+// ── /cso Finding #4: bounded deserialization proptest ────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// Random byte buffers up to 100 KiB fed to DelegationChain::from_bytes must
+    /// never panic — they may return Ok or Err but must terminate safely.
+    ///
+    /// This is the security-critical regression test for /cso Finding #4
+    /// (fingerprint `30a553fc`): bincode 1.x allocation DoS via crafted u64
+    /// length prefixes. The bounded deserializer must catch these before any
+    /// allocation attempt.
+    #[test]
+    fn prop_chain_from_bytes_never_panics_large_input(
+        bytes in proptest::collection::vec(any::<u8>(), 0..102_400),
+    ) {
+        // Must not panic, OOM, or hang — may return Ok or Err.
+        let _ = DelegationChain::from_bytes(&bytes);
+    }
+}


### PR DESCRIPTION
## Summary

- Each `from_bytes` (PqcCredential, DelegationToken, DelegationChain, SignedAuditEvent) gets a length pre-check + bincode `with_limit` defense in depth
- Limits: 4 KiB (cred), 8 KiB (token), 32 KiB (chain), 16 KiB (audit) — tunable per-type `pub const`
- 5 unit tests + 1 64-case proptest

## Findings closed

- #4 — MEDIUM — Bincode 1.x deserialization without allocation cap

## Verification (already run on the branch)

- 107/107 tests pass (6 new tests across this work)
- `cargo run --example bincode_exploit` rejects crafted `[0xFF; 16]` payload in ~20µs
- `cargo run --example boundary_check` rejects 20 KiB well-formed token with `input exceeds maximum size (20180 > 8192)`
- `cargo run --example mutual_auth` happy path unbroken

## Test plan

- [ ] CI green
- [ ] Manual run: `cargo run --example bincode_exploit` shows sub-100ms rejection
- [ ] Manual run: `cargo run --example boundary_check` shows oversized rejection

> ⚠️ Has rustfmt violations against pre-existing main; rebase against #5/#6/#7 to clear the fmt gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
