### PR TITLE
ci: grant checks:write to audit job (fix push-event failures)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
   audit:
     name: Security Audit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

Every merge-to-main has been triggering a failed CI run because `rustsec/audit-check@v2` can't publish a Check Run via GitHub's API on push events — the default `GITHUB_TOKEN` for push events lacks `checks:write` permission. PR events succeed because they inherit `checks:write` by default for same-repo PRs.

11 such failures across this session's merges. The audit itself runs fine (zero vulnerabilities found, one informational warning about bincode being unmaintained).

This adds `permissions: { contents: read, checks: write }` scoped to the `audit` job only (least privilege).

## Test plan

- [ ] PR CI green (already passes)
- [ ] After merge, the post-merge push-to-main CI run passes (the actual validation — fixes the noise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
