### PR TITLE
docs(plan): record DEC-OKAMI-017 + 018 in Decision Log

### DIFF
--- a/MASTER_PLAN.md
+++ b/MASTER_PLAN.md
@@ -138,7 +138,9 @@ Appendix items A1 + A2 from the /cso 2026-04-24 audit have closed (PR #6, commit
 | DEC-OKAMI-014 | DelegationToken::verify rejects mismatched issuer/embedded-credential SPIFFE ID | Without this binding check the embedded credential can be from a different identity than the claimed issuer; allows full bypass of self-contained verification | `src/delegation.rs` |
 | DEC-OKAMI-015 | AgentIdentity::from_stored takes a PqcCredential and verifies key/credential pairing | Re-minting timestamps on every load made expiry illusory and broke revocation-by-bytes; the binding check catches mismatched signing.key/credential.bin pairs | `src/identity.rs` |
 | DEC-OKAMI-016 | Bounded bincode deserialization with per-type input-size caps + `with_limit` | Bincode 1.x has no default allocation cap; a crafted 8-byte length prefix triggers exabyte allocation; well-formed oversized inputs deserve rejection too | `src/delegation.rs`, `src/identity.rs`, `src/audit.rs` |
+| DEC-OKAMI-017 | Domain-separated signatures across token / audit / revocation protocols (1-byte domain tag prepended before signing) | Without domain separation a signature crafted in one protocol could verify against another, enabling cross-protocol signature reuse. Wire-format break from pre-0.1.1 signatures. /cso Appendix A1. | `src/identity.rs`, `src/delegation.rs`, `src/audit.rs` |
+| DEC-OKAMI-018 | `load_signing_key` verifies file owner UID matches effective UID via libc `geteuid()` | Mode-0600 alone is insufficient — a key file owned by another UID can be silently replaced by that user. UID check matches full SSH model (ssh-keygen refuses non-owner keys). No new crate dep. /cso Appendix A2. | `src/identity.rs` |
 
 ## Review Status
 
-CEO + ENG CLEARED. Phase 1 complete. 16 decisions documented. Security hardening pass (/cso 2026-04-24) merged across PRs #1-#4.
+CEO + ENG CLEARED. Phase 1 complete. 18 decisions documented. Security hardening pass (/cso 2026-04-24) merged across PRs #1-#6.


### PR DESCRIPTION
## Summary

Catch up MASTER_PLAN.md with two security decisions already shipped in code (PR #6, commit `6e6c738`) so `surface.sh` stops emitting an "Unplanned Decisions" section in DECISIONS.md.

- **DEC-OKAMI-017** — Domain-separated signatures across token / audit / revocation protocols (1-byte domain tag prepended before signing). /cso 2026-04-24 Appendix A1.
- **DEC-OKAMI-018** — `load_signing_key` verifies file owner UID matches effective UID via libc `geteuid()`. /cso 2026-04-24 Appendix A2.

Plus a Review Status counter bump: `16 decisions / PRs #1-#4` → `18 decisions / PRs #1-#6`.

## Why

The annotations for both decisions already live in `src/identity.rs` (and 017 also touches `src/delegation.rs` + `src/audit.rs`) from PR #6. The Decision Log table in MASTER_PLAN.md hadn't been updated to match, so `surface.sh` was flagging them as "drift" each time it regenerated DECISIONS.md.

Per `CLAUDE.md` §9, MASTER_PLAN.md updates must route through a `docs/plan-*` branch + PR rather than a direct push to main — that's why this tiny edit is going through the PR flow.

## What

- `MASTER_PLAN.md`: appended two rows to the Decision Log table; bumped Review Status counter.
- No code changes. `DECISIONS.md` is **not** in this PR — the committed copy on main already lists 017+018 under "By Component"; only the planning-doc side was lagging.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo test` — 118 passing, 0 failures
- [ ] After merge: re-run `scripts/surface.sh` on main; confirm DECISIONS.md is byte-stable (no "Unplanned Decisions" section emitted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)