### PR TITLE
chore(ci): replace cargo-audit with cargo-deny

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,18 +46,18 @@ jobs:
       - name: Tests
         run: cargo test --all
 
-  audit:
-    name: Security Audit
+  deny:
+    name: Supply-Chain Audit (cargo-deny)
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      checks: write
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - name: cargo audit
-        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998  # v2.0.0
+      - name: cargo-deny
+        uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb  # v2.0.17
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          command: check advisories licenses bans sources
+          rust-version: "1.85"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,119 @@
+# deny.toml — cargo-deny configuration for okami
+#
+# Schema reference: https://embarkstudios.github.io/cargo-deny/
+# Verified against cargo-deny v0.19 schema.
+#
+# Sections:
+#   [advisories] — RustSec advisory DB: vulnerabilities, unsound code, unmaintained crates.
+#   [licenses]   — SPDX license allowlist for the full transitive dependency tree.
+#   [bans]       — Duplicate-version detection and wildcard-version policy.
+#   [sources]    — Restrict package sources to crates.io; deny unknown registries and git sources.
+
+# ---------------------------------------------------------------------------
+# [advisories]
+# Checks the RustSec Advisory Database for known vulnerabilities, unsound
+# code, and unmaintained crates. Vulnerabilities always produce errors in
+# cargo-deny v0.18+ and cannot be downgraded (use ignore for targeted
+# exceptions with documented justification only).
+# ---------------------------------------------------------------------------
+[advisories]
+# Use the default RustSec advisory DB (https://github.com/rustsec/advisory-db).
+# db-urls defaults to this; no override needed.
+
+# unmaintained = "all": any crate with an unmaintained advisory errors,
+# whether direct or transitive. Direct deps that are knowingly unmaintained
+# but safe are listed in the ignore block below with rationale.
+unmaintained = "all"
+
+# unsound = "all": any crate with an unsoundness advisory errors.
+unsound = "all"
+
+# Targeted exceptions — each entry MUST have a documented reason.
+ignore = [
+    # RUSTSEC-2025-0141: bincode 1.x — the bincode maintainer team disbanded
+    # due to a harassment incident and declared v1.3.3 a "complete, final"
+    # release. No security vulnerability exists; the crate is feature-frozen,
+    # not broken. Okami uses bincode only for internal serialization with
+    # allocation bounds (PR #4 added a deserialization cap). Upgrading to an
+    # alternative (postcard, bitcode) is tracked as a separate maintenance
+    # item. Safe to suppress here.
+    { id = "RUSTSEC-2025-0141", reason = "bincode 1.3.3 is feature-frozen but not broken; okami applies allocation caps (PR #4). Migration to a maintained alternative is a separate task." },
+]
+
+# ---------------------------------------------------------------------------
+# [licenses]
+# Every crate in the transitive dependency tree must have a license that
+# satisfies at least one SPDX identifier in the allow list. The list below
+# was derived by running `cargo deny check licenses` against the actual
+# Cargo.lock and adding every identifier that appeared in an OR expression
+# where at least one alternative is OSI-approved and permissive.
+#
+# Notably absent:
+#   LGPL-2.1-or-later — appears only in `r-efi` as a third OR option
+#     alongside MIT and Apache-2.0; cargo-deny resolves the OR by finding
+#     MIT/Apache-2.0 first. No LGPL crate is being linked.
+#   GPL-* — not present anywhere in the dep tree.
+# ---------------------------------------------------------------------------
+[licenses]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",  # rustc/LLVM-derived crates (e.g. wasi)
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-DFS-2016",
+    "Unicode-3.0",    # unicode-ident — "(MIT OR Apache-2.0) AND Unicode-3.0"
+    "CC0-1.0",
+    "Zlib",
+    "MPL-2.0",
+    "0BSD",
+    "BSL-1.0",
+    "Unlicense",      # memchr — "Unlicense OR MIT"; both are in the allowlist
+]
+
+# Require 93% license-text confidence to avoid misidentification.
+# Stricter than the 0.8 default; appropriate for a security-focused crate.
+confidence-threshold = 0.93
+
+# ---------------------------------------------------------------------------
+# [bans]
+# Warns on duplicate transitive versions (noise signal for future dep
+# consolidation), and hard-denies wildcard version constraints.
+#
+# Duplicate versions in this project come from the PQC dep tree (lupine uses
+# newer digest/sha2/sha3 than the stable ecosystem), which is unavoidable
+# without upstream version alignment. `multiple-versions = "warn"` flags
+# them without blocking PRs.
+# ---------------------------------------------------------------------------
+[bans]
+# Warn on duplicate crate versions in the dep tree — doesn't block PRs but
+# surfaces consolidation opportunities.
+multiple-versions = "warn"
+
+# Deny `version = "*"` in any Cargo.toml in the workspace.
+wildcards = "deny"
+
+# No crates are unconditionally banned yet.
+deny = []
+
+# No skip entries — the duplicate-version warnings from lupine's PQC dep
+# tree are transient (expected to resolve as the ecosystem converges on
+# newer digest/sha2/sha3 versions). No skip needed as these are warnings,
+# not errors.
+skip = []
+
+# ---------------------------------------------------------------------------
+# [sources]
+# Restrict package origin to crates.io. Any crate pulled from an unknown
+# registry or an unlisted git source fails the check.
+# ---------------------------------------------------------------------------
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+
+# Only crates.io is an allowed registry.
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+
+# No git sources — all dependencies are published crates.
+allow-git = []


### PR DESCRIPTION
Closes #14.

## Summary

Replace the `cargo-audit` CI job with `cargo-deny`. cargo-deny is a strict superset of cargo-audit — it runs the same RustSec advisory check, plus license allowlist enforcement, banned-crate policy, duplicate-version detection, and source-registry restriction, all in a single job. This is pre-publish supply-chain hardening: licenses and source registries are now policy-enforced on every PR, not just inspected manually.

## Configuration highlights (`deny.toml`)

- **`[advisories]`** — `unmaintained = "all"` and `unsound = "all"`; vulnerabilities always error in cargo-deny v0.18+. One documented ignore (see below).
- **`[licenses]`** — Permissive SPDX allowlist (MIT, Apache-2.0 +LLVM-exception, BSD-2/3-Clause, ISC, Unicode-{DFS-2016, 3.0}, CC0-1.0, Zlib, MPL-2.0, 0BSD, BSL-1.0, Unlicense). All 123 transitive crates pass. `confidence-threshold = 0.93` (stricter than the 0.8 default).
- **`[bans]`** — `multiple-versions = "warn"` (the lupine PQC dep tree has expected digest/sha2/sha3 duplicates that resolve as the ecosystem converges); `wildcards = "deny"`; no unconditional bans yet.
- **`[sources]`** — Only `crates.io` allowed; `unknown-registry = "deny"`, `unknown-git = "deny"`. No git deps.

## One documented ignore

- **RUSTSEC-2025-0141** — bincode 1.x is flagged unmaintained because the maintainer team disbanded after a harassment incident and declared v1.3.3 a "complete, final" release. It is feature-frozen, not vulnerable. Okami uses bincode only for internal serialization with allocation caps (DEC-OKAMI-016 / PR #4); the only relevant attack surface is mitigated. Migration to a maintained alternative (postcard, bitcode) is tracked separately as a maintenance item.

## CI workflow

`rustsec/audit-check@v2.0.0` replaced by `EmbarkStudios/cargo-deny-action@v2.0.17` (SHA-pinned to `91bf2b620e09e18d6eb78b92e7861937469acedb`). `checks: write` permission removed — cargo-deny does not post check-runs, only fails the job exit code. The `test` job (fmt, clippy, cargo test on Rust 1.85 + stable) is untouched.

## Test plan

- [x] `cargo deny check advisories` — clean
- [x] `cargo deny check licenses` — clean (7 cosmetic forward-compat "not-encountered" warnings on allowlist entries)
- [x] `cargo deny check bans` — clean (duplicate-version warnings as designed)
- [x] `cargo deny check sources` — clean
- [x] `cargo deny check` (all-in-one) — clean
- [x] Negative enforcement test: temporarily banned `serde` → exit 2, `error[banned]: crate 'serde = 1.0.228' is explicitly banned`, then reverted
- [x] `cargo test` — 123 passing, no regression (no source files modified)
- [x] CI workflow validated as syntactically correct YAML

## Note for reviewer

Once merged, every future PR is gated by this policy. The first contributor PR after merge may surface licenses-not-yet-on-the-allowlist for unusual transitive deps — that's exactly the point of installing the gate. Add new SPDX identifiers to `[licenses].allow` with a short comment if/when this happens.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>