### PR TITLE
docs(api): comprehensive doc-comment audit + compile-enforced coverage

### DIFF
--- a/MASTER_PLAN.md
+++ b/MASTER_PLAN.md
@@ -141,7 +141,8 @@ Appendix items A1 + A2 from the /cso 2026-04-24 audit have closed (PR #6, commit
 | DEC-OKAMI-017 | Domain-separated signatures across token / audit / revocation protocols (1-byte domain tag prepended before signing) | Without domain separation a signature crafted in one protocol could verify against another, enabling cross-protocol signature reuse. Wire-format break from pre-0.1.1 signatures. /cso Appendix A1. | `src/identity.rs`, `src/delegation.rs`, `src/audit.rs` |
 | DEC-OKAMI-018 | `load_signing_key` verifies file owner UID matches effective UID via libc `geteuid()` | Mode-0600 alone is insufficient — a key file owned by another UID can be silently replaced by that user. UID check matches full SSH model (ssh-keygen refuses non-owner keys). No new crate dep. /cso Appendix A2. | `src/identity.rs` |
 | DEC-OKAMI-019 | Public `RevocationStatement::verify(verifying_key_bytes, claimed_credential_bytes)` helper | Hand-reconstructing the signed payload (`target_bytes || revoked_at_secs.to_le_bytes()` under `DOMAIN_REVOCATION`) is a footgun that silently accepts forged revocations or rejects valid ones; first-party helper mirrors `DelegationToken::verify` and `SignedAuditEvent::verify` ergonomics. | `src/identity.rs` |
+| DEC-OKAMI-020 | `#![deny(missing_docs)]` at crate root + `# Errors` on every Result-returning public function + `# Examples` on flagship public types | Once published to crates.io every `pub` item is a stable contract; compile-time enforcement prevents API surface drifting away from documentation. | `src/lib.rs` |
 
 ## Review Status
 
-CEO + ENG CLEARED. Phase 1 complete. 19 decisions documented. Security hardening pass (/cso 2026-04-24) merged across PRs #1-#6.
+CEO + ENG CLEARED. Phase 1 complete. 20 decisions documented. Security hardening pass (/cso 2026-04-24) merged across PRs #1-#6.

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -51,6 +51,40 @@ pub const MAX_SIGNED_AUDIT_EVENT_BYTES: u64 = 16 * 1024;
 /// The `details` field is therefore stored as a pre-serialized JSON string
 /// (`details_json`). Use [`AuditEvent::details`] / [`AuditEvent::new`] for
 /// ergonomic `serde_json::Value` access.
+///
+/// # Examples
+///
+/// ```
+/// use okami::identity::{AgentIdentity, SpiffeId};
+/// use okami::audit::AuditEvent;
+///
+/// let identity = AgentIdentity::new("example.com", "agent/worker").unwrap();
+/// let vk_bytes = identity.credential().verifying_key_bytes.clone();
+///
+/// // First event in a new chain (no previous hash).
+/// let ev = AuditEvent::new(
+///     identity.spiffe_id().clone(),
+///     "delegation.issued",
+///     serde_json::json!({"target": "worker/1", "scopes": ["read:db"]}),
+///     None,
+/// );
+/// assert_eq!(ev.chain_hash, "");
+/// assert_eq!(ev.action, "delegation.issued");
+///
+/// // Sign to produce a verifiable event.
+/// let signed = ev.sign(&identity).unwrap();
+/// assert!(signed.verify(&vk_bytes).unwrap());
+///
+/// // Link the next event by passing the previous event's hash.
+/// let prev_hash = signed.hash_hex().unwrap();
+/// let ev2 = AuditEvent::new(
+///     identity.spiffe_id().clone(),
+///     "key.rotated",
+///     serde_json::json!({}),
+///     Some(prev_hash.clone()),
+/// );
+/// assert_eq!(ev2.chain_hash, prev_hash);
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AuditEvent {
     /// Format version (currently 1).
@@ -140,6 +174,32 @@ impl AuditEvent {
 /// A signed audit event: an [`AuditEvent`] plus PQC signature bytes.
 ///
 /// Produced by [`AuditEvent::sign`]. Verify with [`SignedAuditEvent::verify`].
+///
+/// # Examples
+///
+/// ```
+/// use okami::identity::AgentIdentity;
+/// use okami::audit::{AuditEvent, SignedAuditEvent};
+///
+/// let identity = AgentIdentity::new("example.com", "agent/worker").unwrap();
+/// let vk_bytes = identity.credential().verifying_key_bytes.clone();
+///
+/// let ev = AuditEvent::new(
+///     identity.spiffe_id().clone(),
+///     "key.rotated",
+///     serde_json::json!({}),
+///     None,
+/// );
+/// let signed: SignedAuditEvent = ev.sign(&identity).unwrap();
+///
+/// // Signature is valid with the correct key.
+/// assert!(signed.verify(&vk_bytes).unwrap());
+///
+/// // Round-trip through bytes.
+/// let bytes = signed.to_bytes().unwrap();
+/// let signed2 = SignedAuditEvent::from_bytes(&bytes).unwrap();
+/// assert!(signed2.verify(&vk_bytes).unwrap());
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SignedAuditEvent {
     /// The audit event payload.
@@ -193,6 +253,10 @@ impl SignedAuditEvent {
     }
 
     /// Serialize to bytes (bincode).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Serialization`] if bincode encoding fails.
     pub fn to_bytes(&self) -> Result<Vec<u8>> {
         bincode::serialize(self)
             .map_err(|e| Error::Serialization(format!("signed event serialize: {e}")))

--- a/src/delegation.rs
+++ b/src/delegation.rs
@@ -76,6 +76,8 @@ pub struct Capability(String);
 impl Capability {
     /// Parse and validate a capability scope string.
     ///
+    /// # Errors
+    ///
     /// Returns [`Error::InvalidScope`] if the string is empty or contains whitespace.
     pub fn new(scope: &str) -> Result<Self> {
         if scope.is_empty() {
@@ -132,6 +134,39 @@ struct UnsignedToken {
 ///
 /// Contains: issuer SPIFFE ID, subject SPIFFE ID, scopes, validity window,
 /// parent chain linkage, embedded issuer credential, and PQC signature.
+///
+/// # Examples
+///
+/// ```
+/// use okami::identity::{AgentIdentity, SpiffeId};
+/// use okami::delegation::{Capability, DelegationToken};
+/// use std::time::Duration;
+///
+/// let issuer = AgentIdentity::new("example.com", "orchestrator").unwrap();
+/// let subject = SpiffeId::new("example.com", "worker/1").unwrap();
+/// let scopes = vec![Capability::new("read:db").unwrap()];
+///
+/// // Issue a root token (no parent).
+/// let token = DelegationToken::issue(
+///     &issuer,
+///     subject,
+///     scopes.clone(),
+///     &scopes,
+///     Duration::from_secs(3600),
+///     None,
+/// ).unwrap();
+///
+/// assert_eq!(token.depth, 0);
+/// assert!(token.parent_token_hash.is_none());
+///
+/// // Verify signature and validity window.
+/// token.verify(None).unwrap();
+///
+/// // Round-trip through bytes (e.g. for network transport).
+/// let bytes = token.to_bytes().unwrap();
+/// let token2 = DelegationToken::from_bytes(&bytes).unwrap();
+/// token2.verify(None).unwrap();
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DelegationToken {
     /// Issuer SPIFFE ID.
@@ -246,7 +281,16 @@ impl DelegationToken {
     ///
     /// # Parameters
     ///
-    /// - `clock_skew` — grace period (default: 30 seconds)
+    /// - `clock_skew` — grace period (default: [`DEFAULT_CLOCK_SKEW_SECS`] seconds)
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::ChainVerificationFailed`] if the claimed issuer does not match the
+    ///   embedded credential's SPIFFE ID, or if the PQC signature is invalid
+    /// - [`Error::TokenExpired`] if the token's validity window has passed
+    /// - [`Error::TokenNotYetValid`] if the token's `issued_at` is too far in the future
+    /// - [`Error::Serialization`] if the unsigned payload cannot be re-serialized
+    /// - [`Error::Crypto`] if the verifying key in the embedded credential is structurally invalid
     //
     // @decision DEC-OKAMI-014
     // @title Verify embedded credential SPIFFE ID matches claimed issuer
@@ -317,6 +361,10 @@ impl DelegationToken {
     }
 
     /// Serialize this token to bytes (bincode).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Serialization`] if bincode encoding fails.
     pub fn to_bytes(&self) -> Result<Vec<u8>> {
         bincode::serialize(self).map_err(|e| Error::Serialization(format!("token serialize: {e}")))
     }
@@ -348,6 +396,10 @@ impl DelegationToken {
     }
 
     /// Return a SHA-256 hash of this token's serialized bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Serialization`] if bincode encoding fails.
     pub fn hash(&self) -> Result<[u8; 32]> {
         let bytes = self.to_bytes()?;
         Ok(Sha256::digest(&bytes).into())
@@ -361,6 +413,46 @@ impl DelegationToken {
 /// The chain is ordered root-first. Verification checks each token individually
 /// plus structural integrity: parent hash linkage, scope attenuation, depth
 /// limit, and issuer/subject linkage across hops.
+///
+/// # Examples
+///
+/// ```
+/// use okami::identity::{AgentIdentity, SpiffeId};
+/// use okami::delegation::{Capability, DelegationToken, DelegationChain};
+/// use std::time::Duration;
+///
+/// let orchestrator = AgentIdentity::new("example.com", "orchestrator").unwrap();
+/// let worker = AgentIdentity::new("example.com", "worker/1").unwrap();
+/// let sub_id = SpiffeId::new("example.com", "sub-worker/1").unwrap();
+/// let scopes = vec![Capability::new("read:db").unwrap()];
+///
+/// // Root token: orchestrator -> worker.
+/// let root = DelegationToken::issue(
+///     &orchestrator,
+///     worker.spiffe_id().clone(),
+///     scopes.clone(),
+///     &scopes,
+///     Duration::from_secs(3600),
+///     None,
+/// ).unwrap();
+///
+/// // Child token: worker -> sub-worker (attenuated scopes).
+/// let child = DelegationToken::issue(
+///     &worker,
+///     sub_id,
+///     scopes.clone(),
+///     &root.scopes,
+///     Duration::from_secs(1800),
+///     Some(&root),
+/// ).unwrap();
+///
+/// let chain = DelegationChain::new(vec![root, child]);
+/// chain.verify(None).unwrap();
+///
+/// // Effective scopes are the leaf token's scopes.
+/// assert_eq!(chain.effective_scopes().len(), 1);
+/// assert_eq!(chain.effective_scopes()[0].as_str(), "read:db");
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DelegationChain {
     /// Ordered tokens, root at index 0.
@@ -375,7 +467,17 @@ impl DelegationChain {
 
     /// Verify the entire delegation chain.
     ///
-    /// Checks per-token validity then structural integrity across all links.
+    /// Checks per-token validity then structural integrity across all links:
+    /// each token's signature and expiry, depth ordering, parent-hash linkage,
+    /// scope attenuation, and issuer/subject continuity across hops.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::ChainVerificationFailed`] if the chain is empty, a token's depth
+    ///   does not match its position, the parent hash does not match, a scope
+    ///   escalation is detected, or the issuer/subject chain is broken
+    /// - Any error propagated from [`DelegationToken::verify`] for each token
+    ///   (see its `# Errors` section)
     pub fn verify(&self, clock_skew: Option<StdDuration>) -> Result<()> {
         if self.tokens.is_empty() {
             return Err(Error::ChainVerificationFailed("chain is empty".to_string()));
@@ -454,6 +556,10 @@ impl DelegationChain {
     }
 
     /// Serialize this chain to bytes (bincode).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Serialization`] if bincode encoding fails.
     pub fn to_bytes(&self) -> Result<Vec<u8>> {
         bincode::serialize(self).map_err(|e| Error::Serialization(format!("chain serialize: {e}")))
     }
@@ -486,10 +592,12 @@ impl DelegationChain {
 
     /// Render an ASCII tree visualization of this chain.
     ///
-    /// Example:
-    ///   [0] spiffe://example.com/orchestrator [read:db, write:api]
-    ///    -> [1] spiffe://example.com/worker [read:db]
-    ///        -> [2] spiffe://example.com/sub-worker [read:db]
+    /// Example output:
+    /// ```text
+    /// [0] spiffe://example.com/orchestrator [read:db, write:api]
+    ///  -> [1] spiffe://example.com/worker [read:db]
+    ///      -> [2] spiffe://example.com/sub-worker [read:db]
+    /// ```
     pub fn ascii_tree(&self) -> String {
         let mut out = String::new();
         for (i, token) in self.tokens.iter().enumerate() {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 //! Unified error type for the okami Agent Passport SDK.
 //!
-//! All okami operations surface errors through the single [`Error`] enum.
+//! All okami operations surface errors through the single [`enum@Error`] enum.
 //! This keeps the API simple: callers import one type and match on
 //! meaningful variants without nested conversion chains.
 //!

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -46,7 +46,7 @@
 //! @title Bounded bincode deserialization to prevent allocation DoS
 //! @status accepted
 //! @rationale bincode 1.x reads a raw u64 length prefix before allocating for
-//!   Vec<T>/String fields. A crafted payload with `[0xFF; 8]` as the first field
+//!   `Vec<T>`/String fields. A crafted payload with `[0xFF; 8]` as the first field
 //!   causes an immediate multi-exabyte allocation attempt, crashing the process.
 //!   Fix: use `DefaultOptions::with_fixint_encoding().allow_trailing_bytes().with_limit(N)`
 //!   which exactly mirrors the free-function encoding but adds an allocation cap.
@@ -156,6 +156,25 @@ pub const DOMAIN_REVOCATION: u8 = 0x03;
 /// - Trust domain must be non-empty and contain only valid hostname characters
 /// - Path (workload ID) must be non-empty
 /// - No query strings or fragments allowed
+///
+/// # Examples
+///
+/// ```
+/// use okami::identity::SpiffeId;
+///
+/// let id = SpiffeId::new("example.com", "agent/worker-1").unwrap();
+/// assert_eq!(id.trust_domain(), "example.com");
+/// assert_eq!(id.workload_path(), "/agent/worker-1");
+/// assert_eq!(id.as_str(), "spiffe://example.com/agent/worker-1");
+///
+/// // Parse an existing URI string.
+/// let parsed: SpiffeId = "spiffe://corp.internal/orchestrator".parse().unwrap();
+/// assert_eq!(parsed.trust_domain(), "corp.internal");
+///
+/// // Invalid inputs are rejected.
+/// assert!(SpiffeId::new("bad domain", "agent").is_err());
+/// assert!(SpiffeId::parse("http://not-spiffe/agent").is_err());
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct SpiffeId {
     /// The full URI string, e.g. `spiffe://example.com/agent/worker-1`.
@@ -282,6 +301,24 @@ impl std::str::FromStr for SpiffeId {
 ///
 /// Serialized with serde/bincode. The `algo` field identifies the key type
 /// for forward compatibility. Version 1 uses hybrid Ed25519+ML-DSA-65.
+///
+/// # Examples
+///
+/// ```
+/// use okami::identity::{AgentIdentity, PqcCredential};
+///
+/// // Obtain a credential from an identity (contains only public material).
+/// let identity = AgentIdentity::new("example.com", "agent/worker").unwrap();
+/// let cred: PqcCredential = identity.credential();
+///
+/// assert!(!cred.is_expired());
+/// assert!(cred.is_valid_at(chrono::Utc::now()));
+///
+/// // Round-trip through bytes (e.g. for network transport).
+/// let bytes = cred.to_bytes().unwrap();
+/// let cred2 = PqcCredential::from_bytes(&bytes).unwrap();
+/// assert_eq!(cred.spiffe_id, cred2.spiffe_id);
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PqcCredential {
     /// SPIFFE ID identifying the agent this credential belongs to.
@@ -352,6 +389,30 @@ impl PqcCredential {
 /// Produced by [`AgentIdentity::revoke`]. The `target_credential_bytes` field
 /// contains the bincode-serialized [`PqcCredential`] being revoked; the
 /// `signature` covers those bytes.
+///
+/// # Examples
+///
+/// ```
+/// use okami::identity::AgentIdentity;
+///
+/// let identity = AgentIdentity::new("example.com", "agent/worker").unwrap();
+/// let cred = identity.credential();
+/// let cred_bytes = cred.to_bytes().unwrap();
+///
+/// // Produce a revocation statement signed by the identity.
+/// let stmt = identity.revoke().unwrap();
+/// assert!(!stmt.signature.is_empty());
+///
+/// // Verify the statement using the agent's public verifying key.
+/// let vk_bytes = cred.verifying_key_bytes.clone();
+/// let valid = stmt.verify(&vk_bytes, &cred_bytes).unwrap();
+/// assert!(valid);
+///
+/// // A wrong credential does not verify.
+/// let other = AgentIdentity::new("example.com", "agent/other").unwrap();
+/// let other_cred_bytes = other.credential().to_bytes().unwrap();
+/// assert!(!stmt.verify(&vk_bytes, &other_cred_bytes).unwrap());
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RevocationStatement {
     /// The bincode bytes of the credential being revoked.
@@ -423,6 +484,31 @@ impl RevocationStatement {
 ///   for a transition period
 /// - [`AgentIdentity::revoke`] — produce a signed revocation statement
 /// - [`AgentIdentity::is_expired`] — check if the current credential is expired
+///
+/// # Examples
+///
+/// ```
+/// use okami::identity::AgentIdentity;
+///
+/// // Generate a fresh identity.
+/// let identity = AgentIdentity::new("example.com", "agent/worker").unwrap();
+/// assert_eq!(identity.spiffe_id().trust_domain(), "example.com");
+///
+/// // Sign and verify arbitrary data.
+/// let sig = identity.sign(b"hello okami").unwrap();
+/// assert!(identity.verify(b"hello okami", &sig).unwrap());
+/// assert!(!identity.verify(b"tampered", &sig).unwrap());
+///
+/// // Share the public credential (safe to send to peers).
+/// let cred = identity.credential();
+/// assert!(!cred.is_expired());
+///
+/// // Persist and reload from stored bytes.
+/// let key_bytes = identity.signing_key_bytes();
+/// let reloaded = AgentIdentity::from_stored(cred, &key_bytes).unwrap();
+/// let sig2 = reloaded.sign(b"hello okami").unwrap();
+/// assert!(reloaded.verify(b"hello okami", &sig2).unwrap());
+/// ```
 pub struct AgentIdentity {
     spiffe_id: SpiffeId,
     signing_key: lupine::sign::HybridSigningKey65,
@@ -541,7 +627,7 @@ impl AgentIdentity {
     /// the provided `verifying_key_bytes`. Returns `Ok(true)` if valid,
     /// `Ok(false)` if the signature does not match.
     ///
-    /// Use the same `domain` constant that was passed to [`sign_with_domain`]
+    /// Use the same `domain` constant that was passed to [`AgentIdentity::sign_with_domain`]
     /// at the corresponding sign site.
     ///
     /// # Errors

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,10 +34,30 @@
 //!
 //! | Module | Contents |
 //! |--------|---------|
-//! | [`error`] | Unified [`Error`] type and [`Result`] alias |
-//! | [`identity`] | [`AgentIdentity`], [`SpiffeId`], [`PqcCredential`] |
-//! | [`delegation`] | [`DelegationToken`], [`DelegationChain`], [`Capability`] |
-//! | [`audit`] | [`AuditEvent`], [`SignedAuditEvent`], audit chain verification |
+//! | [`error`] | Unified [`enum@Error`] type and [`Result`] alias |
+//! | [`identity`] | [`identity::AgentIdentity`], [`identity::SpiffeId`], [`identity::PqcCredential`] |
+//! | [`delegation`] | [`delegation::DelegationToken`], [`delegation::DelegationChain`], [`delegation::Capability`] |
+//! | [`audit`] | [`audit::AuditEvent`], [`audit::SignedAuditEvent`], audit chain verification |
+//!
+//! @decision DEC-OKAMI-020
+//! @title Compile-enforced public API documentation coverage
+//! @status accepted
+//! @rationale Once published to crates.io (PR-1, issue #12), every `pub`
+//!   symbol becomes a stable contract that downstream code can pin against.
+//!   Undocumented or under-documented public items are a maintenance liability
+//!   — they force consumers to read source, and they let API drift slip into
+//!   releases without anyone noticing. `#![deny(missing_docs)]` at the crate
+//!   root makes documentation gaps a compile error, not a code-review nice-to-
+//!   have. The bar (top-level summary on all pub items; `# Errors` on every
+//!   `Result`-returning function; `# Examples` on flagship types and their
+//!   primary methods) is enforced partly by the compiler (`missing_docs`) and
+//!   partly by `cargo test --doc` (every example must compile and run).
+//!   The companion lint `#![deny(rustdoc::broken_intra_doc_links)]` makes
+//!   ambiguous or stale doc references a build error too — without it, the
+//!   only signal would be a `cargo doc` warning easy to overlook.
+
+#![deny(missing_docs)]
+#![deny(rustdoc::broken_intra_doc_links)]
 
 pub mod audit;
 pub mod delegation;


### PR DESCRIPTION
**Closes #16.**

## Summary

Pre-publish doc quality pass before crates.io 0.1.0. This is the third leg of the publish-prep tripod:

- **PR #20** — `cargo-deny` supply-chain enforcement (merged)
- **PR #19** — `RevocationStatement::verify` helper (merged)
- **This PR** — public-API doc-comment audit + compile-enforced doc coverage

Once these three land, every `pub` item in `okami` ships to crates.io with a documented contract, an `# Errors` clause where it returns `Result`, and a runnable `# Examples` block on flagship types — and the compiler will refuse to build if a future PR regresses any of that.

## What's in this PR

Four deliverables, all in `src/` plus one plan row:

1. **Missing doc fixes** — every `pub` item across `identity.rs`, `delegation.rs`, `audit.rs`, `error.rs`, `lib.rs` now has a top-level summary doc comment. Disambiguated two ambiguous `[`Error`]` intra-doc links to `[`enum@Error`]` (one in `lib.rs`, one in `error.rs` module header).
2. **`# Errors` blocks** — every `Result`-returning public function now documents the conditions under which it returns each error variant.
3. **`# Examples` blocks** — flagship public types (`AgentIdentity`, `PqcCredential`, `SpiffeId`, `RevocationStatement`, `DelegationToken`, `DelegationChain`, `Capability`, `AuditEvent`, `SignedAuditEvent`) now ship at least one runnable doctest each. Doctest count: 2 → 10.
4. **Two `#![deny(...)]` attributes at the crate root**, in `src/lib.rs`:
   ```rust
   #![deny(missing_docs)]
   #![deny(rustdoc::broken_intra_doc_links)]
   ```
   These flip doc-quality from a code-review nice-to-have to a build error.

## Test plan

| Gate | Result |
|---|---|
| `cargo build` | clean |
| `cargo doc --no-deps` warnings | **0** |
| `#![deny(rustdoc::broken_intra_doc_links)]` negative test | **exit 101**, `error: unresolved link to NonExistentType` (then reverted) |
| `cargo test` | **131 passing** (was 123 baseline; +8 from new doctests on flagship types) |
| `cargo clippy --all-targets -- -D warnings` | clean |
| `cargo fmt --check` | clean |
| Diff scope | exactly six files: `MASTER_PLAN.md`, `src/{lib,identity,delegation,audit,error}.rs` |

The negative test is the load-bearing one: the tester injected a `[`NonExistentType`]` link into a doc comment and confirmed `cargo doc --no-deps` actually fails with the expected `error: unresolved link` and exit 101 — i.e. the lint genuinely fires on the kind of bug it's supposed to catch. Reverted before commit.

## DEC-OKAMI-020

From the `@decision` block in `src/lib.rs`:

> Once published to crates.io (PR-1, issue #12), every `pub` symbol becomes a stable contract that downstream code can pin against. Undocumented or under-documented public items are a maintenance liability — they force consumers to read source, and they let API drift slip into releases without anyone noticing. `#![deny(missing_docs)]` at the crate root makes documentation gaps a compile error, not a code-review nice-to-have. The bar (top-level summary on all pub items; `# Errors` on every `Result`-returning function; `# Examples` on flagship types and their primary methods) is enforced partly by the compiler (`missing_docs`) and partly by `cargo test --doc` (every example must compile and run). The companion lint `#![deny(rustdoc::broken_intra_doc_links)]` makes ambiguous or stale doc references a build error too — without it, the only signal would be a `cargo doc` warning easy to overlook.

Logged in MASTER_PLAN.md row DEC-OKAMI-020 (counter bumped 19 → 20).

## Note for reviewer

Once this merges, **all future PRs touching `pub` items will be required (at compile time) to document them**. Initial drag is small — every flagship type already has its example block in this PR. Future drag is also small — when the lint fires, the message is self-explanatory ("missing documentation for a public item" / "unresolved link to ..."), and the fix is mechanical: add `///` doc, or fix the typo'd link target.

This is the kind of policy that's almost free to maintain once it's in place but very hard to retrofit later — every undocumented `pub` item that ships to crates.io is one a future audit will have to chase down. Cheaper to enforce from day one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)