### PR TITLE
chore(publish): exclude harness state, bump 0.1.0 → 0.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .DS_Store
 tmp/
 .gstack/
+.claude/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "okami"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "okami"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Post-quantum cryptographic identity for AI agents"
@@ -9,6 +9,14 @@ repository = "https://github.com/im40percentgit/okami"
 homepage = "https://github.com/im40percentgit/okami"
 keywords = ["post-quantum", "cryptography", "identity", "agent", "spiffe"]
 categories = ["cryptography", "authentication"]
+exclude = [
+    ".claude/",
+    ".github/",
+    ".gstack/",
+    "tmp/",
+    "MASTER_PLAN.md",
+    "DECISIONS.md",
+]
 
 [[bin]]
 name = "okami"


### PR DESCRIPTION
Refs #12 (pre-flight that unblocks PR-1; #12 itself closes when the maintainer runs `cargo publish`).

## Why

Three things conspired to make a naive `cargo publish` actively dangerous:

1. **Harness state was being packaged.** The repo's `.gitignore` only listed `tmp/` and `.gstack/`. The Claude harness writes its working state to `.claude/` (200+ subagent-tracker files, audit logs, proof statuses, the test-status fixture, etc.), and cargo-publish includes any tracked-or-untracked-but-not-ignored path it finds under the package root. Every single one of those files would have been permanently archived on crates.io — yanking does not delete the tarball, it only marks it un-resolvable. Internal state would have been observable forever.

2. **Version collision.** `okami 0.1.0` already exists on crates.io from a much earlier publish — pre-/cso security pass, pre-multi-OS-matrix, pre-DEC-019/020/021. Re-publishing `0.1.0` would have been refused by the registry, AND every security improvement we've shipped since then would have silently failed to ship. The fact that cargo refuses to overwrite is doing us a favor here, not blocking us.

3. **Semver communicates intent.** DEC-OKAMI-017 introduced a signature wire-format break. Pre-1.0 semver puts breaking changes on the minor bump. `0.2.0` tells consumers "wire format changed, re-pin" without ambiguity.

## What changed

Three files, +11/-2 total:

- **`.gitignore`** — appended `.claude/` after the existing `.gstack/` entry. Future `cargo publish` runs will see `.claude/` as ignored and won't try to pack it.
- **`Cargo.toml`** — added `exclude = [".claude/", ".github/", ".gstack/", "tmp/", "MASTER_PLAN.md", "DECISIONS.md"]` under `[package]` as defense-in-depth (cargo refuses these paths even if `.gitignore` drifts later); bumped `version = "0.1.0"` → `version = "0.2.0"`.
- **`Cargo.lock`** — auto-regenerated by `cargo build`; single-line change to the `name = "okami"` block's `version` field, reflecting the bump.

## Test plan

| Gate | Result |
|---|---|
| `cargo package --list` | 24 files, no `.claude/`, no `.github/`, no plan artifacts, no harness state |
| `cargo publish --dry-run` | clean, packaging `okami v0.2.0`, no "already exists" warning |
| `cargo build` | clean |
| `cargo test` | 131 passing (82 unit + 18 cli_e2e + 21 proptest + 10 doctests; 0 failures) |
| `cargo clippy --all-targets -D warnings` | clean |
| `cargo fmt --check` | clean |
| `cargo doc --no-deps` warning count | 0 (DEC-020 lints still satisfied) |
| Diff scope | exactly the 3 files above |

## What happens after merge

The maintainer runs, in order:

- `cargo publish` — uploads `okami 0.2.0` to crates.io with all the security fixes, multi-OS support, and DEC-019/020/021 changes.
- `cargo yank --version 0.1.0` — retires the obsolete public version so new resolvers won't pick it up. (Existing `Cargo.lock` files that already pinned `0.1.0` continue to work — yank only affects new resolution.)

## Non-blocking follow-ups

- The tester flagged `CLAUDE.md` (project-level Claude instructions) as also-not-useful-to-end-consumers of the crate. Not added to `exclude` here to keep this PR's diff minimal and reviewable; can land as a one-line follow-up before or after the eventual `1.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)