### PR TITLE
chore(deps): bump lupine-sign 0.1.1 -> 0.1.2; clarify pkcs8 pin rationale

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -846,9 +846,9 @@ dependencies = [
 
 [[package]]
 name = "lupine-sign"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef83472744a43b9d0547212ca0b6ad87c34ffc7326e3346ced50b2d53812b15e"
+checksum = "a12768f1e171a7b6279e0dbebc1b3f078f9216206553d409be014b3c6fa2e044"
 dependencies = [
  "ed25519-dalek",
  "lupine-core",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -806,9 +806,9 @@ dependencies = [
 
 [[package]]
 name = "lupine-sign"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef83472744a43b9d0547212ca0b6ad87c34ffc7326e3346ced50b2d53812b15e"
+checksum = "a12768f1e171a7b6279e0dbebc1b3f078f9216206553d409be014b3c6fa2e044"
 dependencies = [
  "ed25519-dalek",
  "lupine-core",
@@ -835,7 +835,7 @@ dependencies = [
  "const-oid 0.10.2",
  "hybrid-array 0.4.11",
  "module-lattice",
- "pkcs8 0.11.0-rc.11",
+ "pkcs8 0.11.0",
  "rand_core 0.10.0",
  "sha3 0.11.0",
  "signature 3.0.0-rc.10",
@@ -900,7 +900,6 @@ version = "0.0.0"
 dependencies = [
  "libfuzzer-sys",
  "okami",
- "pkcs8 0.11.0-rc.11",
 ]
 
 [[package]]
@@ -948,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.11.0-rc.11"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12922b6296c06eb741b02d7b5161e3aaa22864af38dfa025a1a3ba3f68c84577"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
  "der 0.8.0",
  "spki 0.8.0",
@@ -1219,7 +1218,7 @@ dependencies = [
  "digest 0.11.2",
  "hmac 0.13.0",
  "hybrid-array 0.4.11",
- "pkcs8 0.11.0-rc.11",
+ "pkcs8 0.11.0",
  "rand_core 0.10.0",
  "sha2 0.11.0",
  "sha3 0.11.0",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -835,7 +835,7 @@ dependencies = [
  "const-oid 0.10.2",
  "hybrid-array 0.4.11",
  "module-lattice",
- "pkcs8 0.11.0",
+ "pkcs8 0.11.0-rc.11",
  "rand_core 0.10.0",
  "sha3 0.11.0",
  "signature 3.0.0-rc.10",
@@ -900,6 +900,7 @@ version = "0.0.0"
 dependencies = [
  "libfuzzer-sys",
  "okami",
+ "pkcs8 0.11.0-rc.11",
 ]
 
 [[package]]
@@ -947,9 +948,9 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.11.0"
+version = "0.11.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+checksum = "12922b6296c06eb741b02d7b5161e3aaa22864af38dfa025a1a3ba3f68c84577"
 dependencies = [
  "der 0.8.0",
  "spki 0.8.0",
@@ -1218,7 +1219,7 @@ dependencies = [
  "digest 0.11.2",
  "hmac 0.13.0",
  "hybrid-array 0.4.11",
- "pkcs8 0.11.0",
+ "pkcs8 0.11.0-rc.11",
  "rand_core 0.10.0",
  "sha2 0.11.0",
  "sha3 0.11.0",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -5,8 +5,9 @@ publish = false
 edition = "2021"
 
 # cargo-fuzz creates a standalone workspace so it doesn't unify features with
-# the parent crate. Without this, feature resolution can activate a problematic
-# pkcs8 path on `ml-dsa-rc.7` that fails on current nightly.
+# the parent crate. lupine-sign >= 0.1.2 already disables ml-dsa's `pkcs8`
+# default feature (the source of the nightly compile bug in ml-dsa-rc.7), so
+# isolation here is defense-in-depth against future feature-unification surprises.
 [workspace]
 
 [package.metadata]
@@ -14,13 +15,6 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
-# Pin pkcs8 to the rc version that ml-dsa-rc.7 and slh-dsa-rc.4 were written
-# against. pkcs8 0.11.0 stable changed KeyMalformed from a variant to a
-# function, which breaks compilation of those crates. An explicit version
-# requirement here forces the resolver to use the rc — cargo's minimal version
-# rules will still satisfy any dep requiring >= rc.10. Remove this pin when
-# ml-dsa / slh-dsa ship releases targeting pkcs8 0.11.0 stable.
-pkcs8 = "=0.11.0-rc.11"
 
 [dependencies.okami]
 path = ".."

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -5,9 +5,7 @@ publish = false
 edition = "2021"
 
 # cargo-fuzz creates a standalone workspace so it doesn't unify features with
-# the parent crate. lupine-sign >= 0.1.2 already disables ml-dsa's `pkcs8`
-# default feature (the source of the nightly compile bug in ml-dsa-rc.7), so
-# isolation here is defense-in-depth against future feature-unification surprises.
+# the parent crate.
 [workspace]
 
 [package.metadata]
@@ -15,6 +13,20 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
+# Pin pkcs8 to the rc series. With the pin removed, cargo resolves to
+# pkcs8 0.11.0 (stable), where `Error::KeyMalformed` became a tuple variant
+# `KeyMalformed(KeyError)` instead of the old unit/fn-pointer form. That breaks
+# slh-dsa-0.2.0-rc.4's source (it uses `pkcs8::Error::KeyMalformed` as a
+# function pointer in `?`-position) — slh-dsa hits the same upstream bug
+# pattern that lupine-sign 0.1.2 worked around for ml-dsa-rc.7.
+#
+# lupine-sign 0.1.2 set `default-features = false` on its `ml-dsa` dep, which
+# eliminated the ml-dsa half of the problem (its pkcs8.rs is feature-gated and
+# now never compiled). slh-dsa's broken code is **not** behind a feature flag,
+# so the same trick can't be applied — see lupine-sign Cargo.toml comment.
+#
+# Remove this pin once slh-dsa ships a release targeting pkcs8 0.11.0 stable.
+pkcs8 = "=0.11.0-rc.11"
 
 [dependencies.okami]
 path = ".."


### PR DESCRIPTION
Refs #24.

## Summary

Originally this PR aimed to drop the `pkcs8 = "=0.11.0-rc.11"` pin from `fuzz/Cargo.toml` after the lupine-sign 0.1.2 publish landed the structural fix for the ml-dsa half of the upstream bug. Re-running the nightly fuzz workflow on this branch with the pin removed proved that the pin is still needed: **slh-dsa-0.2.0-rc.4 hits the same `KeyMalformed` bug pattern** in its own source, and that code is not behind a feature flag (so the lupine-sign trick can't be applied).

Revised scope:

- **Bump `lupine-sign` 0.1.1 → 0.1.2** in both lockfiles. Real value: ml-dsa's broken `pkcs8.rs` no longer compiles in the okami dep graph, even though pkcs8 0.11.0-rc.11 stays as a transitive dep.
- **Keep the pkcs8 pin**, but rewrite the rationale comment so the next maintainer understands what it's now actually protecting (slh-dsa-rc.4's source, not feature unification, and not the ml-dsa bug — that one is upstream-fixed).

Issue #24 stays open as a tracked follow-up — its title was specifically about ml-dsa, and that's resolved upstream, but the broader "drop the pkcs8 pin entirely" goal is still gated on a slh-dsa release targeting pkcs8 0.11.0 stable.

## Diff

- `Cargo.lock` — `lupine-sign 0.1.1 -> 0.1.2`
- `fuzz/Cargo.lock` — `lupine-sign 0.1.1 -> 0.1.2` (no change to pkcs8: stays at 0.11.0-rc.11)
- `fuzz/Cargo.toml` — pin restored; rationale comment rewritten to point at slh-dsa-rc.4 as the live constraint

## Test plan

- [x] `cargo fmt --all -- --check` — exit 0 (Windows local)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — exit 0 (Windows local)
- [x] `cargo test --all` — 128/128 (Windows local, with `RUSTDOCFLAGS=-C link-arg=/STACK:33554432`)
- [ ] CI matrix (linux + macos + windows × 1.85 + stable) — green on this PR
- [ ] Fuzz workflow on nightly — re-dispatched against this branch

## What got us here

First push removed the pin → `gh workflow run fuzz.yml` against the branch → all 4 targets failed with `slh-dsa` compile errors against `pkcs8 0.11.0` stable (`KeyMalformed` tuple-variant breakage). Logs showed the failure was inside `slh-dsa-0.2.0-rc.4/src/...`, not anywhere in our or lupine's code. The fuzz workflow was the right place to discover this — the lupine workspace's own `cargo +nightly check` doesn't exercise feature unification through the okami fuzz subcrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)