### PR TITLE
fix(fuzz): drop --locked so cargo-fuzz install resolves a working rustix

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -32,7 +32,7 @@ jobs:
           rustup toolchain install nightly --profile minimal --component rust-src
 
       - name: Install cargo-fuzz
-        run: cargo +nightly install --locked cargo-fuzz
+        run: cargo +nightly install cargo-fuzz
 
       - name: Cache fuzz target
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5


### PR DESCRIPTION
## Why

Every nightly `Fuzz` cron has failed since 2026-05-09 at the **Install cargo-fuzz** step. CI on push is unaffected.

Root cause: `cargo +nightly install --locked cargo-fuzz` resolves cargo-fuzz v0.13.1's published `Cargo.lock`, which pins `rustix 0.36.5`. That rustix uses perma-unstable `#[rustc_layout_scalar_valid_range_start]` attributes. Recent nightly rustc tightened gating on `rustc_*` attrs, so the build now fails:

```
error: attributes starting with `rustc` are reserved for use by the `rustc` compiler
error: cannot find attribute `rustc_layout_scalar_valid_range_start` in this scope
error: could not compile `rustix` (lib) due to 4 previous errors
error: failed to compile `cargo-fuzz v0.13.1`
```

## Fix

Drop `--locked` from the install command. We don't need lockfile reproducibility for the **tool's** own dep tree — we only need a working cargo-fuzz binary. The fuzz **targets** still resolve from this repo's `Cargo.lock`.

## Verified

Triggered via `workflow_dispatch` on this branch — [run 26524674155](https://github.com/im40percentgit/okami/actions/runs/26524674155) — all 4 matrix targets green:

- `Fuzz (delegation_chain_from_bytes)` ✓
- `Fuzz (spiffe_id_parse)` ✓
- `Fuzz (pqc_credential_from_bytes)` ✓
- `Fuzz (signed_audit_event_from_bytes)` ✓

Each job: install cargo-fuzz clean, 60s fuzz run clean, ~2m28s total.

## If it breaks again

Next escalation is switching to a prebuilt cargo-fuzz binary via `taiki-e/install-action` or `cargo-binstall` — skips the source compile entirely and is immune to nightly toolchain churn.